### PR TITLE
Freeze transform_to_value

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['3.1', '3.2', '3.3']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/README.md
+++ b/README.md
@@ -847,7 +847,11 @@ I18n keys:
 
 #### `transform_to_value(value)`
 
-Always returns ValidResult. The value is transformed to provided argument (disregarding the original value). Returned value deeply freezes with [`Ractor::make_shareable`](https://docs.ruby-lang.org/en/master/Ractor.html#method-c-make_shareable). See also [`default`](#defaultdefault_value-on-nil).
+Always returns ValidResult. The value is transformed to provided argument (disregarding the original value).
+
+Returned value is deeply freezed with [`Ractor::make_shareable`](https://docs.ruby-lang.org/en/master/Ractor.html#method-c-make_shareable) to prevent application bugs due to modification of unintentionally shared value. If that effect is undesired, use [`transform { value }`](#transform--value--) instead.
+
+See also [`default`](#defaultdefault_value-on-nil).
 
 ### "Web-form" types
 

--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ I18n keys:
 
 #### `transform_to_value(value)`
 
-Always returns ValidResult. The value is transformed to provided argument (disregarding the original value). See also [`default`](#defaultdefault_value-on-nil).
+Always returns ValidResult. The value is transformed to provided argument (disregarding the original value). Returned value deeply freezes with [`Ractor::make_shareable`](https://docs.ruby-lang.org/en/master/Ractor.html#method-c-make_shareable). See also [`default`](#defaultdefault_value-on-nil).
 
 ### "Web-form" types
 

--- a/datacaster.gemspec
+++ b/datacaster.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Run-time type checker and transformer for Ruby}
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3')
 
   spec.metadata['source_code_uri'] = 'https://github.com/EugZol/datacaster'
   spec.homepage    = 'https://github.com/EugZol/datacaster'

--- a/datacaster.gemspec
+++ b/datacaster.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Run-time type checker and transformer for Ruby}
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
 
   spec.metadata['source_code_uri'] = 'https://github.com/EugZol/datacaster'
   spec.homepage    = 'https://github.com/EugZol/datacaster'

--- a/lib/datacaster/absent.rb
+++ b/lib/datacaster/absent.rb
@@ -19,5 +19,9 @@ module Datacaster
     def present?
       false
     end
+
+    def ==(other)
+      other.is_a?(self.class)
+    end
   end
 end

--- a/lib/datacaster/predefined.rb
+++ b/lib/datacaster/predefined.rb
@@ -276,7 +276,7 @@ module Datacaster
     end
 
     def transform_to_value(value)
-      transform { value }
+      transform { Datacaster::Utils.deep_freeze(value) }
     end
 
     def with(keys, caster)

--- a/lib/datacaster/utils.rb
+++ b/lib/datacaster/utils.rb
@@ -2,6 +2,10 @@ module Datacaster
   module Utils
     extend self
 
+    def deep_freeze(value, copy: true)
+      Ractor.make_shareable(value, copy:)
+    end
+
     def merge_errors(left, right)
       add_error_to_base = ->(hash, error) {
         hash[:base] ||= []

--- a/lib/datacaster/version.rb
+++ b/lib/datacaster/version.rb
@@ -1,3 +1,3 @@
 module Datacaster
-  VERSION = "3.2.8"
+  VERSION = "3.3.0"
 end

--- a/spec/datacaster_spec.rb
+++ b/spec/datacaster_spec.rb
@@ -1033,12 +1033,31 @@ RSpec.describe Datacaster do
   end
 
   describe "constant mapping" do
-    it "returns exact value" do
-      t = Datacaster.schema { transform_to_value("Test") }
+    let(:transform_to_value_caster) do
+      Datacaster.schema { transform_to_value({ a: { b: { c: "d" } } }) }
+    end
 
-      expect(t.(123).to_dry_result).to eq Success("Test")
+    let(:returned_value) do
+      transform_to_value_caster.(123).value!
+    end
+
+    it "returns exact value" do
+      expect(returned_value).to eq({ a: { b: { c: "d" } } })
+    end
+
+    it "freezes returned value" do
+      expect(returned_value).to be_frozen
+    end
+
+    it "freezes deeply" do
+      expect { returned_value[:a][:b][:c].upcase! }.to raise_error FrozenError
+    end
+
+    it "becomes shareable" do
+      expect(Ractor.shareable?(returned_value)).to be true
     end
   end
+
 
   describe "pass_if casting" do
     subject { Datacaster.schema { pass_if(check { |x| x[:test] == 0 }) } }

--- a/spec/datacaster_spec.rb
+++ b/spec/datacaster_spec.rb
@@ -1058,7 +1058,6 @@ RSpec.describe Datacaster do
     end
   end
 
-
   describe "pass_if casting" do
     subject { Datacaster.schema { pass_if(check { |x| x[:test] == 0 }) } }
 

--- a/spec/datacaster_spec.rb
+++ b/spec/datacaster_spec.rb
@@ -1034,7 +1034,7 @@ RSpec.describe Datacaster do
 
   describe "constant mapping" do
     let(:transform_to_value_caster) do
-      Datacaster.schema { transform_to_value({ a: { b: { c: "d" } } }) }
+      Datacaster.schema { transform_to_value({ a: { b: { c: ["d"] } } }) }
     end
 
     let(:returned_value) do
@@ -1042,7 +1042,7 @@ RSpec.describe Datacaster do
     end
 
     it "returns exact value" do
-      expect(returned_value).to eq({ a: { b: { c: "d" } } })
+      expect(returned_value).to eq({ a: { b: { c: ["d"] } } })
     end
 
     it "freezes returned value" do
@@ -1050,7 +1050,7 @@ RSpec.describe Datacaster do
     end
 
     it "freezes deeply" do
-      expect { returned_value[:a][:b][:c].upcase! }.to raise_error FrozenError
+      expect { returned_value[:a][:b][:c].pop }.to raise_error FrozenError
     end
 
     it "becomes shareable" do

--- a/spec/datacaster_spec.rb
+++ b/spec/datacaster_spec.rb
@@ -1052,10 +1052,6 @@ RSpec.describe Datacaster do
     it "freezes deeply" do
       expect { returned_value[:a][:b][:c].pop }.to raise_error FrozenError
     end
-
-    it "becomes shareable" do
-      expect(Ractor.shareable?(returned_value)).to be true
-    end
   end
 
   describe "pass_if casting" do


### PR DESCRIPTION
This MR prevents bug when pass mutable object to `transform_to_value`. After these changes returned objects will become frozen