### PR TITLE
Fix generating OpenApi specs for `pattern` caster

### DIFF
--- a/datacaster.gemspec
+++ b/datacaster.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dry-monads', '>= 1.3', '< 1.4'
 
   spec.add_runtime_dependency 'zeitwerk', '>= 2', '< 3'
+  spec.add_runtime_dependency 'js_regex'
 end

--- a/lib/datacaster/predefined.rb
+++ b/lib/datacaster/predefined.rb
@@ -366,9 +366,11 @@ module Datacaster
       error_keys = ['.pattern', 'datacaster.errors.pattern']
       error_keys.unshift(error_key) if error_key
 
+      ecma_regexp = JsRegex.new(regexp).to_s
+
       string(error_key) & check { |x| x.match?(regexp) }.
-        i18n_key(*error_keys, reference: regexp.inspect).
-        json_schema(pattern: JsRegex.new(regexp).to_s)
+        i18n_key(*error_keys, reference: ecma_regexp).
+        json_schema(pattern: ecma_regexp)
     end
 
     # 'hash' would be a bad method name, because it would override built in Object#hash

--- a/lib/datacaster/predefined.rb
+++ b/lib/datacaster/predefined.rb
@@ -1,3 +1,5 @@
+require 'js_regex'
+
 module Datacaster
   module Predefined
     extend self
@@ -363,8 +365,10 @@ module Datacaster
     def pattern(regexp, error_key = nil)
       error_keys = ['.pattern', 'datacaster.errors.pattern']
       error_keys.unshift(error_key) if error_key
-      string(error_key) & check { |x| x.match?(regexp) }.i18n_key(*error_keys, reference: regexp.inspect).
-        json_schema(pattern: regexp.inspect)
+
+      string(error_key) & check { |x| x.match?(regexp) }.
+        i18n_key(*error_keys, reference: regexp.inspect).
+        json_schema(pattern: JsRegex.new(regexp).to_s)
     end
 
     # 'hash' would be a bad method name, because it would override built in Object#hash
@@ -458,7 +462,9 @@ module Datacaster
     def uuid(error_key = nil)
       error_keys = ['.uuid', 'datacaster.errors.uuid']
       error_keys.unshift(error_key) if error_key
-      pattern(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, error_key).i18n_key(*error_keys)
+      pattern(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, error_key).
+        i18n_key(*error_keys).
+        json_schema { { 'type' => 'string', 'format' => 'uuid' } }
     end
 
     # Form request types

--- a/lib/datacaster/version.rb
+++ b/lib/datacaster/version.rb
@@ -1,3 +1,3 @@
 module Datacaster
-  VERSION = "6.0.2"
+  VERSION = "6.0.3"
 end

--- a/spec/json_schema_spec.rb
+++ b/spec/json_schema_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Datacaster do
           },
           {
             "properties" => {
-              "id" => {"pattern" => "/\\A\\h{8}-\\h{4}-\\h{4}-\\h{4}-\\h{12}\\z/", "type" => "string"},
+              "id" => {"format" => "uuid", "type" => "string"},
               "kind" => {"enum" => ["uuid"], "type" => "string"},
             },
             "required" => ["id"],
@@ -499,10 +499,7 @@ RSpec.describe Datacaster do
         end
 
       expect(schema.to_json_schema).to eq(
-        {
-          "type"=>"string",
-          "pattern" => "/\\A\\h{8}-\\h{4}-\\h{4}-\\h{4}-\\h{12}\\z/"
-        },
+        {"format" => "uuid", "type" => "string"}
       )
     end
 
@@ -513,7 +510,7 @@ RSpec.describe Datacaster do
         end
 
       expect(schema.to_json_schema).to eq({
-       "items" => {"pattern"=>"/\\A\\h{8}-\\h{4}-\\h{4}-\\h{4}-\\h{12}\\z/", "type"=>"string"},
+       "items" => {"format" => "uuid", "type" => "string"},
        "type" => "array",
       })
     end
@@ -527,7 +524,7 @@ RSpec.describe Datacaster do
       expect(schema.to_json_schema).to eq({
        "anyOf" => [
          { "type" => "null" },
-         {"items"=>{"pattern"=>"/\\A\\h{8}-\\h{4}-\\h{4}-\\h{4}-\\h{12}\\z/", "type"=>"string"}, "type"=>"array"},
+         {"items"=>{"format" => "uuid", "type" => "string"}, "type"=>"array"},
        ],
       })
     end
@@ -539,7 +536,7 @@ RSpec.describe Datacaster do
         end
 
       expect(schema.to_json_schema).to eq({
-       "items" => {"pattern"=>"/\\A\\h{8}-\\h{4}-\\h{4}-\\h{4}-\\h{12}\\z/", "type"=>"string"},
+       "items" => {"format" => "uuid", "type" => "string"},
        "type" => "array",
       })
     end


### PR DESCRIPTION
Currently, the `pattern` caster uses the plain `regexp.inspect` method to generate an OpenApi schema. This approach will not work for some patterns, because the Ruby processor differs from the [ECMA 262](https://www.ecma-international.org/publications-and-standards/standards/ecma-262/) specification used in the OpenApi standard. The current approach generates invalid schemas, which breaks code generators and previews.

e.g.:
Ruby regex (`\A`, `\z`, `\h`) in OpenAPI 3.1 - code generators will choke
<img width="776" height="78" alt="image" src="https://github.com/user-attachments/assets/4963fdd1-7f6c-4cf4-8705-077abac20b1f" />
